### PR TITLE
Fix Gravity Flow inbox approve/reject actions

### DIFF
--- a/src/Providers/ShortcodeServiceProvider.php
+++ b/src/Providers/ShortcodeServiceProvider.php
@@ -197,8 +197,9 @@ class ShortcodeServiceProvider
                 'stats' => $result['stats'] ?? [],
                 'attributes' => $atts,
                 'current_page' => $current_page,
-                'nonce' => \wp_create_nonce('gravity_flow_inbox_action'),
+                'nonce' => \wp_create_nonce('gravity_flow_bulk_action'),
                 'success' => $result['success'],
+                'bulk_action_url' => \rest_url('dnp/v1/gravity/bulk-action'),
                 'inbox_csv_url' => \rest_url('dnp/v1/gravity/inbox/export-csv?uid=' . $current_user_id),
                 'inbox_excel_url' => \rest_url('dnp/v1/gravity/inbox/export-xlsx?uid=' . $current_user_id),
                 'inbox_pdf_url' => \rest_url('dnp/v1/gravity/inbox/export-pdf?uid=' . $current_user_id)


### PR DESCRIPTION
## Summary
- wire the inbox action buttons to the Gravity Flow bulk action REST endpoint and reuse the correct security nonce
- disable buttons while processing and show a spinner plus success/error feedback before refreshing the table
- add minimal styling for disabled buttons so the user sees when an action is in-flight

## Testing
- php -l src/Providers/ShortcodeServiceProvider.php
- php -l views/shortcodes/gravityflow-inbox.view.php

------
https://chatgpt.com/codex/tasks/task_e_68c86a908c588330a7d842ce8ca201ed